### PR TITLE
Package produces console warn due to deprecated parameter

### DIFF
--- a/googlemaps.js
+++ b/googlemaps.js
@@ -35,9 +35,6 @@ GoogleMaps.init = function(parameters, callback) {
     script.src = ("https:" === document.location.protocol ? "https:" : "http:") + '//maps.googleapis.com/maps/api/js';
     
     parameters = parameters || {};
-    if ('undefined' == typeof parameters['sensor']) {
-        parameters['sensor'] = false;
-    };
     parameters['callback'] = 'GoogleMaps.callback';
 
     var queryString = "?";


### PR DESCRIPTION
Sensor parameter is deprecated and will produce a warning when passed with a request.

> SensorNotRequired	Warning	
The sensor parameter is no longer required for the Google Maps JavaScript API. It won't prevent the Google Maps JavaScript API from working correctly, but we recommend that you remove the sensor parameter from the script element.

https://developers.google.com/maps/documentation/javascript/error-messages